### PR TITLE
refactor: migrate components to Formik Field pattern with fastField support

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -2347,10 +2347,6 @@
       "resolved": "packages/select",
       "link": true
     },
-    "node_modules/@blueprintjs-formik/timezone": {
-      "resolved": "packages/timezone",
-      "link": true
-    },
     "node_modules/@blueprintjs/colors": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@blueprintjs/colors/-/colors-4.2.1.tgz",
@@ -4656,6 +4652,72 @@
       },
       "peerDependencies": {
         "rollup": "^1.20.0 || ^2.0.0"
+      }
+    },
+    "node_modules/@rollup/plugin-typescript": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-12.3.0.tgz",
+      "integrity": "sha512-7DP0/p7y3t67+NabT9f8oTBFE6gGkto4SA6Np2oudYmZE/m1dt8RB0SjL1msMxFpLo631qjRCcBlAbq1ml/Big==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^5.1.0",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.14.0||^3.0.0||^4.0.0",
+        "tslib": "*",
+        "typescript": ">=3.7.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        },
+        "tslib": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-typescript/node_modules/@rollup/pluginutils": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
+      "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-typescript/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true
+    },
+    "node_modules/@rollup/plugin-typescript/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@rollup/pluginutils": {
@@ -38317,7 +38379,7 @@
     },
     "packages/core": {
       "name": "@blueprintjs-formik/core",
-      "version": "0.3.7",
+      "version": "0.3.8",
       "license": "ISC",
       "dependencies": {
         "lodash.get": "^4.4.2",
@@ -38326,6 +38388,7 @@
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
+        "@rollup/plugin-typescript": "^12.3.0",
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^12.1.2",
         "@testing-library/user-event": "^13.5.0",
@@ -38338,7 +38401,8 @@
         "@types/styled-components": "^5.1.22",
         "cross-env": "^7.0.3",
         "rollup": "^2.67.2",
-        "rollup-plugin-typescript2": "^0.31.2",
+        "rollup-plugin-typescript2": "^0.34.1",
+        "tslib": "^2.8.1",
         "typescript": "^4.5.5",
         "webpack": "^5.68.0"
       },
@@ -38346,13 +38410,69 @@
         "@blueprintjs/core": "^3.52.0 || 4 || 5",
         "@blueprintjs/select": "^3.18.12 || 4 || 5",
         "formik": "^2.2.9",
-        "react": "16 || ^17.0.2 || ^18.2.0",
-        "react-dom": "16 || ^17.0.2 || ^18.2.0"
+        "react": "16 || ^17.0.2 || 18",
+        "react-dom": "16 || ^17.0.2 || 18"
       }
+    },
+    "packages/core/node_modules/@rollup/pluginutils": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+      "integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
+      "dev": true,
+      "dependencies": {
+        "estree-walker": "^2.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "packages/core/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true
+    },
+    "packages/core/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/core/node_modules/rollup-plugin-typescript2": {
+      "version": "0.34.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.34.1.tgz",
+      "integrity": "sha512-P4cHLtGikESmqi1CA+tdMDUv8WbQV48mzPYt77TSTOPJpERyZ9TXdDgjSDix8Fkqce6soYz3+fa4lrC93IEkcw==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^4.1.2",
+        "find-cache-dir": "^3.3.2",
+        "fs-extra": "^10.0.0",
+        "semver": "^7.3.7",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "rollup": ">=1.26.3",
+        "typescript": ">=2.4.0"
+      }
+    },
+    "packages/core/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true
     },
     "packages/datetime": {
       "name": "@blueprintjs-formik/datetime",
-      "version": "0.3.7",
+      "version": "0.4.1",
       "license": "ISC",
       "dependencies": {
         "lodash.get": "^4.4.2",
@@ -38361,6 +38481,7 @@
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
+        "@rollup/plugin-typescript": "^12.3.0",
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^12.1.2",
         "@testing-library/user-event": "^13.5.0",
@@ -38374,6 +38495,7 @@
         "cross-env": "^7.0.3",
         "rollup": "^2.67.2",
         "rollup-plugin-typescript2": "^0.31.2",
+        "tslib": "^2.8.1",
         "typescript": "^4.5.5",
         "webpack": "^5.68.0"
       },
@@ -38388,9 +38510,15 @@
         "react-dom": "16 || ^17.0.2 || ^18.2.0"
       }
     },
+    "packages/datetime/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true
+    },
     "packages/select": {
       "name": "@blueprintjs-formik/select",
-      "version": "0.3.5",
+      "version": "0.4.6",
       "license": "ISC",
       "dependencies": {
         "lodash.get": "^4.4.2",
@@ -38425,6 +38553,7 @@
     "packages/timezone": {
       "name": "@blueprintjs-formik/timezone",
       "version": "0.1.0",
+      "extraneous": true,
       "license": "ISC",
       "dependencies": {
         "lodash.get": "^4.4.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueprintjs-formik/core",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "dependencies": {
     "lodash.get": "^4.4.2",
     "lodash.keyby": "^4.6.0",
@@ -30,11 +30,14 @@
       "last 1 safari version"
     ]
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "main": "dist/index.js",
   "module": "./dist/esm/index.js",
   "typings": "./dist/index.d.ts",
   "devDependencies": {
+    "@rollup/plugin-typescript": "^12.3.0",
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.2",
     "@testing-library/user-event": "^13.5.0",
@@ -46,17 +49,18 @@
     "@types/react-dom": "^18.2.0",
     "@types/styled-components": "^5.1.22",
     "cross-env": "^7.0.3",
-    "webpack": "^5.68.0",
     "rollup": "^2.67.2",
-    "rollup-plugin-typescript2": "^0.31.2",
-    "typescript": "^4.5.5"
+    "rollup-plugin-typescript2": "^0.34.1",
+    "tslib": "^2.8.1",
+    "typescript": "^4.5.5",
+    "webpack": "^5.68.0"
   },
   "peerDependencies": {
-    "react": "16 || ^17.0.2 || 18",
-    "react-dom": "16 || ^17.0.2 || 18",
     "@blueprintjs/core": "^3.52.0 || 4 || 5",
     "@blueprintjs/select": "^3.18.12 || 4 || 5",
-    "formik": "^2.2.9"
+    "formik": "^2.2.9",
+    "react": "16 || ^17.0.2 || 18",
+    "react-dom": "16 || ^17.0.2 || 18"
   },
   "description": "Bindings for using Formik and Blueprint.js",
   "repository": {

--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -1,26 +1,38 @@
-import typescript from 'rollup-plugin-typescript2';
+import typescript from '@rollup/plugin-typescript';
 import pkg from './package.json';
 
-const external = ['react'];
+const external = ['react'].concat(Object.keys(pkg.dependencies || []));
 
 const config = [
   {
     input: 'src/index.ts',
+    external,
     plugins: [
       typescript({
-        tsconfig: 'tsconfig.json',
+        tsconfig: './tsconfig.json',
+        outDir: './dist',
+        declaration: true,
+        declarationDir: './dist',
       }),
     ],
-    external: external.concat(Object.keys(pkg.dependencies || [])),
-    output: [
-      { dir: './dist', format: 'cjs', sourcemap: true },
-      {
-        dir: './dist/esm',
-        format: 'es',
-        sourcemap: true,
-        preserveModules: true,
-      },
+    output: { dir: './dist', format: 'cjs', sourcemap: true },
+  },
+  {
+    input: 'src/index.ts',
+    external,
+    plugins: [
+      typescript({
+        tsconfig: './tsconfig.json',
+        outDir: './dist/esm',
+        declaration: false,
+      }),
     ],
+    output: {
+      dir: './dist/esm',
+      format: 'es',
+      sourcemap: true,
+      preserveModules: true,
+    },
   },
 ];
 

--- a/packages/core/src/components/FormGroup.tsx
+++ b/packages/core/src/components/FormGroup.tsx
@@ -1,23 +1,23 @@
 import React from 'react';
-import { FieldMetaProps, FieldInputProps, useField } from 'formik';
+import { FieldMetaProps, FieldInputProps, FormikProps } from 'formik';
 import {
   FormGroup as BPFormGroup,
   Intent,
   FormGroupProps as BPFormGroupProps,
 } from '@blueprintjs/core';
+import { Field, FieldBaseProps } from './FieldBase';
 
-export interface FormGroupProps extends BPFormGroupProps {
+export interface FormGroupProps extends BPFormGroupProps, Pick<FieldBaseProps, 'fastField'> {
   name: string;
   children: React.ReactElement;
 }
 
-/**
- * Transformes field props to form group.
- * @param   {Omit<FormGroupProps, "children">} props
- * @param   {FieldInputProps<any>} field
- * @param   {FieldMetaProps<any>} meta
- * @returns {PBFormGroupProps}
- */
+interface FieldToFormGroupProps extends Omit<FormGroupProps, 'fastField'> {
+  field: FieldInputProps<any>;
+  meta: FieldMetaProps<any>;
+  form: FormikProps<any>;
+}
+
 const fieldToFormGroup = (
   props: Omit<FormGroupProps, 'children'>,
   field: FieldInputProps<any>,
@@ -33,18 +33,17 @@ const fieldToFormGroup = (
   };
 };
 
+const FieldToFormGroup = ({ field, meta, form, children, ...props }: FieldToFormGroupProps) => (
+  <BPFormGroup {...fieldToFormGroup(props, field, meta)}>
+    {children}
+  </BPFormGroup>
+);
+
 /**
  * Form group.
  * @param   {FormGroupProps}
  * @returns {React.JSX}
  */
-export function FormGroup({ children, ...props }: FormGroupProps): JSX.Element {
-  const [field, meta] = useField(props.name);
-
-  return (
-    <BPFormGroup
-      {...fieldToFormGroup(props, field, meta)}
-      children={children}
-    />
-  );
+export function FormGroup({ fastField, ...props }: FormGroupProps): JSX.Element {
+  return <Field {...props} fastField={fastField} component={FieldToFormGroup as React.ComponentType<any>} />;
 }

--- a/packages/datetime/package.json
+++ b/packages/datetime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueprintjs-formik/datetime",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "dependencies": {
     "lodash.get": "^4.4.2",
     "lodash.keyby": "^4.6.0",
@@ -37,6 +37,7 @@
   "module": "./dist/esm/index.js",
   "typings": "./dist/index.d.ts",
   "devDependencies": {
+    "@rollup/plugin-typescript": "^12.3.0",
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.2",
     "@testing-library/user-event": "^13.5.0",
@@ -48,20 +49,21 @@
     "@types/react-dom": "^18.2.0",
     "@types/styled-components": "^5.1.22",
     "cross-env": "^7.0.3",
-    "webpack": "^5.68.0",
     "rollup": "^2.67.2",
     "rollup-plugin-typescript2": "^0.31.2",
-    "typescript": "^4.5.5"
+    "tslib": "^2.8.1",
+    "typescript": "^4.5.5",
+    "webpack": "^5.68.0"
   },
   "peerDependencies": {
-    "react": "16 || ^17.0.2 || ^18.2.0",
-    "react-dom": "16 || ^17.0.2 || ^18.2.0",
+    "@blueprintjs-formik/core": "^0.3.2 || 4 || 5",
     "@blueprintjs/core": "^3.52.0 || 4 || 5",
     "@blueprintjs/datetime": "^3.21.0 || 4 || 5",
     "@blueprintjs/datetime2": "^0.9.0",
     "@blueprintjs/select": "^3.18.12 || 4 || 5",
-    "@blueprintjs-formik/core": "^0.3.2 || 4 || 5",
-    "formik": "^2.2.9"
+    "formik": "^2.2.9",
+    "react": "16 || ^17.0.2 || ^18.2.0",
+    "react-dom": "16 || ^17.0.2 || ^18.2.0"
   },
   "description": "Bindings for using Formik and Blueprint.js",
   "repository": {

--- a/packages/datetime/rollup.config.js
+++ b/packages/datetime/rollup.config.js
@@ -1,26 +1,38 @@
-import typescript from 'rollup-plugin-typescript2';
+import typescript from '@rollup/plugin-typescript';
 import pkg from './package.json';
 
-const external = ['react'];
+const external = ['react'].concat(Object.keys(pkg.dependencies || []));
 
 const config = [
   {
     input: 'src/index.ts',
+    external,
     plugins: [
       typescript({
-        tsconfig: 'tsconfig.json',
+        tsconfig: './tsconfig.json',
+        outDir: './dist',
+        declaration: true,
+        declarationDir: './dist',
       }),
     ],
-    external: external.concat(Object.keys(pkg.dependencies || [])),
-    output: [
-      { dir: './dist', format: 'cjs', sourcemap: true },
-      {
-        dir: './dist/esm',
-        format: 'es',
-        sourcemap: true,
-        preserveModules: true,
-      },
+    output: { dir: './dist', format: 'cjs', sourcemap: true },
+  },
+  {
+    input: 'src/index.ts',
+    external,
+    plugins: [
+      typescript({
+        tsconfig: './tsconfig.json',
+        outDir: './dist/esm',
+        declaration: false,
+      }),
     ],
+    output: {
+      dir: './dist/esm',
+      format: 'es',
+      sourcemap: true,
+      preserveModules: true,
+    },
   },
 ];
 

--- a/packages/datetime/src/components/DateInput.tsx
+++ b/packages/datetime/src/components/DateInput.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { getIn, FieldProps, Field } from 'formik';
+import { getIn, FieldProps } from 'formik';
 import { Intent } from '@blueprintjs/core';
 import {
   DateInput as BPDateInput,
   DateInputProps as BPDateInputProps,
 } from '@blueprintjs/datetime';
-import { FieldBaseProps } from '@blueprintjs-formik/core';
+import { FieldBaseProps, Field } from '@blueprintjs-formik/core';
 
 export interface DateInputProps
   extends Omit<FieldBaseProps, 'children' | 'component' | 'as'>,
@@ -61,21 +61,13 @@ function fieldToDateInput({
 }
 
 /**
- * Transformes field props to date input props.
- * @param {FieldToDateInput} props - Field props
- * @returns {JSX.Element}
- */
-function FieldToDatePicker(props: FieldToDateInput): JSX.Element {
-  return <BPDateInput {...fieldToDateInput(props)} />;
-}
-
-/**
  * Date input Blueprint component binded with Formik.
  * @param {DateInputProps} props - Date input props
  * @returns {JSX.Element}
  */
 export function DateInput({ ...props }: DateInputProps): JSX.Element {
-  return (
-    <Field {...props} component={FieldToDatePicker} />
+  const FieldToDatePicker = (fieldProps: FieldProps): JSX.Element => (
+    <BPDateInput {...fieldToDateInput({ ...fieldProps, ...props })} />
   );
+  return <Field {...props} component={FieldToDatePicker} />;
 }

--- a/packages/datetime/src/components/TimezoneSelect.tsx
+++ b/packages/datetime/src/components/TimezoneSelect.tsx
@@ -1,21 +1,19 @@
 import React from 'react';
-import { getIn, FieldProps, Field } from 'formik';
+import { getIn, FieldProps } from 'formik';
 import { Intent } from '@blueprintjs/core';
 import {
     TimezoneSelect as BPTimezoneSelect,
     TimezoneSelectProps as BPTimezoneSelectProps,
 } from '@blueprintjs/datetime2';
-import { FieldBaseProps } from '@blueprintjs-formik/core';
+import { FieldBaseProps, Field } from '@blueprintjs-formik/core';
 
 export interface TimezoneSelectProps
-    extends Omit<FieldBaseProps, 'children' | 'component' | 'as'>,
-    Omit<BPTimezoneSelectProps, 'value' | 'name' | 'onChange'> {
-    name: string;
+  extends Omit<FieldBaseProps, 'children' | 'component' | 'as'>,
+  Omit<BPTimezoneSelectProps, 'value' | 'name' | 'onChange'> {
+  name: string;
 }
 
-interface FieldToTimezoneSelect
-    extends FieldProps,
-    Omit<TimezoneSelectProps, 'form'> { }
+interface FieldToTimezoneSelect extends FieldProps, Omit<TimezoneSelectProps, 'form'> { }
 
 /**
  * Transforms field props to timezone select props.

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueprintjs-formik/select",
-  "version": "0.4.3",
+  "version": "0.4.6",
   "dependencies": {
     "lodash.get": "^4.4.2",
     "lodash.keyby": "^4.6.0",

--- a/packages/select/src/components/MultiSelect.tsx
+++ b/packages/select/src/components/MultiSelect.tsx
@@ -2,12 +2,12 @@ import React, { useMemo, useCallback, ComponentType } from 'react';
 import {
   MultiSelect as BPMultiSelect,
   MultiSelectProps as BPMultiSelectProps,
-  IItemRendererProps,
+  ItemRendererProps as IItemRendererProps,
   ItemPredicate,
 } from '@blueprintjs/select';
 import { MenuItem } from '@blueprintjs/core';
-import { Field, FieldProps } from 'formik';
-import { FieldBaseProps } from '@blueprintjs-formik/core';
+import { FieldProps } from 'formik';
+import { FieldBaseProps, Field } from '@blueprintjs-formik/core';
 import { getAccessor, mapItemsById } from './utils';
 import {
   FormikItemRenderer,
@@ -280,16 +280,15 @@ export type WithFormikMultiSelectProps<T> = Omit<
 export function withFormikMultiSelect<T extends SelectOptionProps>(
   WrappedComponent: ComponentType<MultiSelectProps<T>>
 ) {
-  // Internal component that bridges Formik field props to the wrapped MultiSelect
-  function FieldToWrappedMultiSelect(
-    props: BaseMultiSelectProps<T> & FieldProps
-  ): JSX.Element {
-    const multiSelectProps = transformFieldToMultiSelectProps(props);
-    return <WrappedComponent {...multiSelectProps} />;
-  }
-
   // The HOC component that uses Field
   function FormikBoundMultiSelect(props: WithFormikMultiSelectProps<T>): JSX.Element {
+    const FieldToWrappedMultiSelect = (fieldProps: FieldProps): JSX.Element => {
+      const multiSelectProps = transformFieldToMultiSelectProps({
+        ...props,
+        ...fieldProps,
+      });
+      return <WrappedComponent {...multiSelectProps} />;
+    };
     return <Field {...props} component={FieldToWrappedMultiSelect} />;
   }
 

--- a/packages/select/src/components/Select.tsx
+++ b/packages/select/src/components/Select.tsx
@@ -10,8 +10,8 @@ import {
   ItemPredicate,
   ItemRenderer,
 } from '@blueprintjs/select';
-import { Field, FieldProps } from 'formik';
-import { FieldBaseProps } from '@blueprintjs-formik/core';
+import { FieldProps } from 'formik';
+import { FieldBaseProps, Field } from '@blueprintjs-formik/core';
 import { Accessor, SelectOptionProps } from './types';
 import { getAccessor } from './utils';
 import { useUncontrolled } from '../utils/use-uncontrolled';
@@ -252,16 +252,15 @@ export type WithFormikSelectProps<T> = Omit<
 export function withFormikSelect<T extends SelectOptionProps>(
   WrappedComponent: ComponentType<SelectProps<T>>
 ) {
-  // Internal component that bridges Formik field props to the wrapped Select
-  function FieldToWrappedSelect(
-    props: BaseSelectProps<T> & FieldProps
-  ): JSX.Element {
-    const selectProps = transformFieldToSelectProps(props);
-    return <WrappedComponent {...selectProps} />;
-  }
-
   // The HOC component that uses Field
   function FormikBoundSelect(props: WithFormikSelectProps<T>): JSX.Element {
+    const FieldToWrappedSelect = (fieldProps: FieldProps): JSX.Element => {
+      const selectProps = transformFieldToSelectProps({
+        ...props,
+        ...fieldProps,
+      });
+      return <WrappedComponent {...selectProps} />;
+    };
     return <Field {...props} component={FieldToWrappedSelect} />;
   }
 

--- a/packages/select/src/components/Suggest.tsx
+++ b/packages/select/src/components/Suggest.tsx
@@ -1,10 +1,10 @@
 import React, { useCallback, ComponentType } from 'react';
-import { Field, FieldProps } from 'formik';
-import { FieldBaseProps } from '@blueprintjs-formik/core';
+import { FieldProps } from 'formik';
+import { FieldBaseProps, Field } from '@blueprintjs-formik/core';
 import {
   Suggest as BPSuggest,
   SuggestProps as BPSuggestProps,
-  IItemRendererProps,
+  ItemRendererProps as IItemRendererProps,
   ItemPredicate,
 } from '@blueprintjs/select';
 import { MenuItem } from '@blueprintjs/core';
@@ -266,15 +266,15 @@ export type WithFormikSuggestProps<T> = Omit<
 export function withFormikSuggest<T extends SuggestOptionProps>(
   WrappedComponent: ComponentType<SuggestProps<T>>
 ) {
-  // Internal component that bridges Formik field props to the wrapped Suggest
-  function FieldToWrappedSuggest(
-    props: BaseSuggestProps<T> & FieldProps
-  ): JSX.Element {
-    const suggestProps = transformFieldToSuggestProps(props);
-    return <WrappedComponent {...suggestProps} />;
-  }
   // The HOC component that uses Field
   function FormikBoundSuggest(props: WithFormikSuggestProps<T>): JSX.Element {
+    const FieldToWrappedSuggest = (fieldProps: FieldProps): JSX.Element => {
+      const suggestProps = transformFieldToSuggestProps({
+        ...props,
+        ...fieldProps,
+      });
+      return <WrappedComponent {...suggestProps} />;
+    };
     return <Field {...props} component={FieldToWrappedSuggest} />;
   }
 

--- a/packages/select/src/components/types.ts
+++ b/packages/select/src/components/types.ts
@@ -1,4 +1,4 @@
-import { IItemRendererProps } from '@blueprintjs/select';
+import { ItemRendererProps } from '@blueprintjs/select';
 
 export interface SelectOptionProps {
   disabled?: boolean;
@@ -19,7 +19,7 @@ export interface FormikItemRendererState {
 
 export type FormikItemRenderer<T> = (
   item: T,
-  itemProps: IItemRendererProps,
+  itemProps: ItemRendererProps,
   { isSelected }: FormikItemRendererState
 ) => JSX.Element | null;
 

--- a/stories/HTMLSelectPage.tsx
+++ b/stories/HTMLSelectPage.tsx
@@ -30,8 +30,8 @@ export const HTMLSelectPage = () => {
       >
         {({ values }) => (
           <Form>
-            <FormGroup name={'value'} label={'Long text'}>
-              <HTMLSelect name={'value'} options={['mohamed', 'jesus']} />
+            <FormGroup name={'value'} label={'Long text'} fastField>
+              <HTMLSelect name={'value'} options={['mohamed', 'jesus']} fastField />
             </FormGroup>
 
             <FormGroup


### PR DESCRIPTION
## Summary

- Migrate `FormGroup`, `DateInput`, `TimezoneSelect`, `Select`, `MultiSelect`, and `Suggest` from `useField` / custom wrappers to the shared `Field` component, propagating `fastField` prop support consistently across all formik-bound components.
- Upgrade the build tooling: replace `rollup-plugin-typescript2` with the official `@rollup/plugin-typescript` in `core` and `datetime`, splitting the Rollup config into separate CJS and ESM builds with aligned `outDir`.
- Add `.npmrc` with `legacy-peer-deps=true` to resolve Blueprint.js v4 / React 18 peer dependency conflicts.
- Bump `@blueprintjs-formik/core` to `0.3.8` and `@blueprintjs-formik/datetime` to `0.4.1`.

## Test plan

- [ ] `npm install` succeeds without peer dependency errors
- [ ] `npm run build` succeeds in `packages/core`
- [ ] `npm run build` succeeds in `packages/datetime`
- [ ] `npm run build` succeeds in `packages/select`
- [ ] Verify `fastField` prop is respected on `FormGroup`, `DateInput`, `TimezoneSelect`, `Select`, `MultiSelect`, and `Suggest` in a sample form
- [ ] Storybook renders affected components without regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)